### PR TITLE
deprecation of isMoveable

### DIFF
--- a/oldVersions/v1.0/basalt.lua
+++ b/oldVersions/v1.0/basalt.lua
@@ -3650,12 +3650,15 @@ local function Frame(name, parent)
         return false
     end
 
+    ---@class Frame
     object = {
         barActive = false,
         barBackground = colors.gray,
         barTextcolor = colors.black,
         barText = "New Frame",
         barTextAlign = "left",
+        isMovable = false,
+        ---@deprecated spelled incorrectly, will be replaced in favor of @see Frame#isMovable
         isMoveable = false,
 
         getType = function(self)
@@ -3721,6 +3724,13 @@ local function Frame(name, parent)
             return self
         end;
 
+        setMovable = function(self, movable)
+            self.isMovable = movable or not self.isMovable
+            self:setVisualChanged()
+            return self;
+        end;
+
+        ---@deprecated spelled incorrectly, will be replaced in favor of @see Frame#setMovable
         setMoveable = function(self, moveable)
             self.isMoveable = moveable or not self.isMoveable
             self:setVisualChanged()

--- a/source/compiler.lua
+++ b/source/compiler.lua
@@ -12,7 +12,6 @@ local requiredFiles = {
     "lib/eventSystem.lua",
     "lib/process.lua",
     "lib/utils.lua",
-
 }
 
 local basalt = ""


### PR DESCRIPTION
Deprecated isMoveable in favor of isMovable
I left the original function to be removed at a later date, with comments as well
[new class annotation for emmy lua](
https://github.com/NoryiE/Basalt/commit/cb36c5856d00feed0507dc04f85aa9c616a93c93#r74045316)
[deprecation comment and new variable](https://github.com/NoryiE/Basalt/commit/cb36c5856d00feed0507dc04f85aa9c616a93c93#r74045302)
[new setMovable globla function](https://github.com/NoryiE/Basalt/commit/cb36c5856d00feed0507dc04f85aa9c616a93c93#r74045374
)
