### PR TITLE
deprecated isMoveable and setMoveable

### DIFF
--- a/source/Frame.lua
+++ b/source/Frame.lua
@@ -78,12 +78,15 @@ local function Frame(name, parent)
         return false
     end
 
+    ---@class Frame
     object = {
         barActive = false,
         barBackground = colors.gray,
         barTextcolor = colors.black,
         barText = "New Frame",
         barTextAlign = "left",
+        isMovable = false,
+        ---@deprecated deprecated in favor of Frame#isMovable
         isMoveable = false,
 
         getType = function(self)
@@ -149,12 +152,18 @@ local function Frame(name, parent)
             return self
         end;
 
+        setMovable = function(self, movable)
+            self.isMovable = movable or not self.isMovable
+            self:setVisualChanged()
+            return self;
+        end;
+
+        ---@deprecated deprecated in favor of @see Frame#setMovable
         setMoveable = function(self, moveable)
             self.isMoveable = moveable or not self.isMoveable
             self:setVisualChanged()
             return self;
         end;
-
 
         showBar = function(self, showIt)
             self.barActive = showIt or not self.barActive


### PR DESCRIPTION
I deprecated isMoveable and setMoveable in favor of isMovable and setMovable as the original ones are spelled incorrectly, and it could lead to mistakes in code

